### PR TITLE
Remove 0 minutes

### DIFF
--- a/lib/readingtime.rb
+++ b/lib/readingtime.rb
@@ -27,7 +27,12 @@ module Readingtime
   end
 
   def self.format_words(seconds)
-    '%d minutes and %d seconds' % seconds.divmod(60)
+    if seconds >= 60
+      '%d minutes and %d seconds' % seconds.divmod(60)
+    else
+      "#{ seconds } seconds"
+    end
+    
   end
 
   def self.format_approx(seconds)

--- a/spec/readingtime_spec.rb
+++ b/spec/readingtime_spec.rb
@@ -52,6 +52,7 @@ describe Readingtime do
   end
 
   it "should accept an options hash to format the output" do
+    ten_words.reading_time(:format => :long).should == "3 seconds"
     two_hundred_words.reading_time(:format => :basic).should == "01:00"
     two_hundred_words.reading_time(:format => :long).should == "1 minutes and 0 seconds"
     two_hundred_words.reading_time(:format => :approx).should == "1 minutes"


### PR DESCRIPTION
This PR changes the behaviour of the long format.

Instead of `0 minutes and 3 seconds`, when the reading time is < 1 minute, it'll just output the number of seconds: `3 seconds`.
